### PR TITLE
Add support for collecting metrics/statistics on pip

### DIFF
--- a/package_metrics/datadog_utils.py
+++ b/package_metrics/datadog_utils.py
@@ -92,7 +92,6 @@ def get_metric_name_for_stats_key(key):
         "Major": "major_outdated",
         "Minor": "minor_outdated",
         "Patch": "patch_outdated",
-        "Exotic": "exotic_outdated",
     }
     return metric_name_map[key]
 

--- a/package_metrics/metrics.py
+++ b/package_metrics/metrics.py
@@ -1,12 +1,12 @@
 import argparse
 
 from package_metrics.datadog_utils import send_stats_to_datadog
-from package_metrics.package_managers.pip import parse_pip
+from package_metrics.package_managers.pip import iter_pip_packages
 
 
 def get_packages(package_manager):
     parsers = {
-        "pip": parse_pip,
+        "pip": iter_pip_packages,
     }
     return parsers[package_manager]()
 

--- a/package_metrics/metrics.py
+++ b/package_metrics/metrics.py
@@ -1,0 +1,48 @@
+import argparse
+
+from package_metrics.package_managers.pip import parse_pip
+
+
+def get_packages(package_manager):
+    parsers = {
+        "pip": parse_pip,
+    }
+    return parsers[package_manager]()
+
+
+def build_packages_table(packages):
+    def build_row(behind, name, current, latest):
+        return f"{behind:8s} {name:28s} {current:12s} {latest}"
+
+    rows = [build_row("Behind", "Package", "Latest", "Version")]
+
+    records = sorted(packages)
+    for delta, name, current, latest in records:
+        if delta:
+            behind = ".".join(str(v) for v in delta)
+        else:
+            behind = "n/a"
+        rows.append(build_row(behind, name, current, latest))
+
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Track dependencies of a project"
+    )
+    parser.add_argument(
+        "package_manager",
+        help="package manager to calculate metrics for",
+        choices=["pip"]
+    )
+    args = parser.parse_args()
+
+    packages = get_packages(args.package_manager)
+    package_table = build_packages_table(packages)
+    for row in package_table:
+        print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/package_metrics/metrics.py
+++ b/package_metrics/metrics.py
@@ -22,7 +22,7 @@ def build_packages_table(packages):
         if delta:
             behind = ".".join(str(v) for v in delta)
         else:
-            behind = "n/a"
+            continue
         rows.append(build_row(behind, name, current, latest))
 
     return rows
@@ -35,7 +35,6 @@ def get_package_stats(packages):
         "Major": 0,
         "Minor": 0,
         "Patch": 0,
-        "Exotic": 0,
     }
     for delta, name, current, latest in packages:
         if delta:
@@ -52,10 +51,8 @@ def get_package_stats(packages):
             else:
                 assert patch and not major and not minor, delta
                 key = "Patch"
-        else:
-            key = "Exotic"  # applies to yarn
-        stats[key] += 1
-        stats["Outdated"] += 1
+            stats[key] += 1
+            stats["Outdated"] += 1
     return stats
 
 
@@ -88,8 +85,7 @@ def main():
         stats = get_package_stats(packages)
         if args.stats:
             # NOTE: subtle detail: we're depending on Python 3's ordered dict to
-            # maintain deterministic ordering here (critical when using
-            # --no-labels).
+            # maintain deterministic ordering here
             for key, value in stats.items():
                 print(f"{key}: {value}")
         elif args.send:

--- a/package_metrics/package_managers/pip.py
+++ b/package_metrics/package_managers/pip.py
@@ -5,8 +5,11 @@ from sh import Command
 from package_metrics.parsing_utils import behind
 
 
-def parse_pip():
-    """Parse the output of ``pip list --format json --outdated``"""
+def iter_pip_packages():
+    """
+    Parse the output of ``pip list --format json --outdated``
+    :return: generator containing version info for installed python packages
+    """
     package_list = _get_pip_packages()
     for pkg in json.loads(package_list):
         latest = pkg["latest_version"]

--- a/package_metrics/package_managers/pip.py
+++ b/package_metrics/package_managers/pip.py
@@ -1,0 +1,22 @@
+import json
+
+from sh import Command
+
+from package_metrics.parsing_utils import behind
+
+
+def parse_pip():
+    """Parse the output of ``pip list --format json --outdated``"""
+    package_list = _get_pip_packages()
+    for pkg in json.loads(package_list):
+        latest = pkg["latest_version"]
+        current = pkg["version"]
+        yield behind(latest, current), pkg["name"], latest, current
+
+
+def _get_pip_packages():
+    """
+    Equivalent to ``pip list --format json --outdated``
+    """
+    pip = Command("pip")
+    return pip("list", "--format", "json", "--outdated")

--- a/package_metrics/parsing_utils.py
+++ b/package_metrics/parsing_utils.py
@@ -1,0 +1,13 @@
+def behind(latest, current):
+    delta = [0, 0, 0]
+    for index, (lat, cur) in enumerate(zip(vsplit(latest), vsplit(current))):
+        if lat != cur:
+            delta[index] = lat - cur
+            break
+    return delta
+
+
+def vsplit(version):
+    padded = f"{version}.0.0"  # append extra zeros for versions like '1' or '2.0'
+    return [int(n) for n in padded.split(".")[:3]]
+

--- a/package_metrics/parsing_utils.py
+++ b/package_metrics/parsing_utils.py
@@ -23,7 +23,7 @@ def parse_version(version):
         try:
             num = int(n)
         except ValueError:
-            match = re.search(r'\d+', n)
+            match = re.search(r'^\d+', n)
             # default to 0, unless
             num = int(match.group()) if match else 0
         semvar_version.append(num)

--- a/package_metrics/parsing_utils.py
+++ b/package_metrics/parsing_utils.py
@@ -1,13 +1,32 @@
+import re
+
+
 def behind(latest, current):
     delta = [0, 0, 0]
-    for index, (lat, cur) in enumerate(zip(vsplit(latest), vsplit(current))):
+    parsed_latest = parse_version(latest)
+    parsed_current = parse_version(current)
+    for index, (lat, cur) in enumerate(zip(parsed_latest, parsed_current)):
         if lat != cur:
             delta[index] = lat - cur
             break
     return delta
 
 
-def vsplit(version):
+def parse_version(version):
+    """
+    :param version: a string representing the package version (e.g., '1.0.1')
+    :return: a list of integers representing [major, minor, patch]
+    """
     padded = f"{version}.0.0"  # append extra zeros for versions like '1' or '2.0'
-    return [int(n) for n in padded.split(".")[:3]]
+    semvar_version = []
+    for n in padded.split(".")[:3]:
+        try:
+            num = int(n)
+        except ValueError:
+            match = re.search(r'\d+', n)
+            # default to 0, unless
+            num = int(match.group()) if match else 0
+        semvar_version.append(num)
+
+    return semvar_version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+[project.scripts]
+package-metrics = "package_metrics.metrics:main"
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ maintainers = [
 license = {file = "LICENSE"}
 dependencies = [
     'requests',
+    'sh',
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/test_datadog_utils.py
+++ b/tests/test_datadog_utils.py
@@ -6,7 +6,17 @@ from unittest.mock import patch
 from freezegun import freeze_time
 
 from package_metrics.constants import MetricType
-from package_metrics.datadog_utils import send_metric
+from package_metrics.datadog_utils import send_metric, send_stats_to_datadog
+
+
+@patch('package_metrics.datadog_utils.send_metric')
+def test_send_stats_to_datadog(mock_send_metric):
+    stats = {'Outdated': 15}
+    send_stats_to_datadog(stats, 'pip')
+    mock_send_metric.assert_called_with(
+        "commcare.static_analysis.dependency.python.outdated",
+        15,
+        MetricType.GAUGE)
 
 
 @patch('package_metrics.datadog_utils.requests.post')

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from package_metrics.metrics import build_packages_table
+
+
+class BuildPackagesTableTests(TestCase):
+
+    def test_header_row(self):
+        packages = []
+        rows = build_packages_table(packages)
+        self.assertEqual(rows[0], "Behind   Package                      Latest       Version")
+
+    def test_row_with_delta(self):
+        packages = [([0, 1, 0], 'test', '1.1', '1.0')]
+        rows = build_packages_table(packages)
+        self.assertEqual(rows[1], "0.1.0    test                         1.1          1.0")
+
+    def test_row_with_no_delta(self):
+        packages = [([0, 0, 0], 'test', '1.0', '1.0')]
+        rows = build_packages_table(packages)
+        self.assertEqual(rows[1], "0.0.0    test                         1.0          1.0")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -32,7 +32,6 @@ class GetPackageStatsTests(TestCase):
             "Major": 0,
             "Minor": 0,
             "Patch": 0,
-            "Exotic": 0,
         })
 
     def test_outdated_major_package(self):
@@ -44,7 +43,6 @@ class GetPackageStatsTests(TestCase):
             "Major": 1,
             "Minor": 0,
             "Patch": 0,
-            "Exotic": 0,
         })
 
     def test_outdated_minor_package(self):
@@ -56,7 +54,6 @@ class GetPackageStatsTests(TestCase):
             "Major": 0,
             "Minor": 1,
             "Patch": 0,
-            "Exotic": 0,
         })
 
     def test_outdated_patch_package(self):
@@ -68,5 +65,4 @@ class GetPackageStatsTests(TestCase):
             "Major": 0,
             "Minor": 0,
             "Patch": 1,
-            "Exotic": 0,
         })

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from package_metrics.metrics import build_packages_table
+from package_metrics.metrics import build_packages_table, get_package_stats
 
 
 class BuildPackagesTableTests(TestCase):
@@ -19,3 +19,54 @@ class BuildPackagesTableTests(TestCase):
         packages = [([0, 0, 0], 'test', '1.0', '1.0')]
         rows = build_packages_table(packages)
         self.assertEqual(rows[1], "0.0.0    test                         1.0          1.0")
+
+
+class GetPackageStatsTests(TestCase):
+
+    def test_outdated_multi_major_package(self):
+        packages = [([2, 0, 0], 'test', '3.1', '1.0')]
+        stats = get_package_stats(packages)
+        self.assertEqual(stats, {
+            "Outdated": 1,
+            "Multi-Major": 1,
+            "Major": 0,
+            "Minor": 0,
+            "Patch": 0,
+            "Exotic": 0,
+        })
+
+    def test_outdated_major_package(self):
+        packages = [([1, 0, 0], 'test', '2.5', '1.0')]
+        stats = get_package_stats(packages)
+        self.assertEqual(stats, {
+            "Outdated": 1,
+            "Multi-Major": 0,
+            "Major": 1,
+            "Minor": 0,
+            "Patch": 0,
+            "Exotic": 0,
+        })
+
+    def test_outdated_minor_package(self):
+        packages = [([0, 5, 0], 'test', '2.5', '2.0')]
+        stats = get_package_stats(packages)
+        self.assertEqual(stats, {
+            "Outdated": 1,
+            "Multi-Major": 0,
+            "Major": 0,
+            "Minor": 1,
+            "Patch": 0,
+            "Exotic": 0,
+        })
+
+    def test_outdated_patch_package(self):
+        packages = [([0, 0, 3], 'test', '2.5.4', '2.5.1')]
+        stats = get_package_stats(packages)
+        self.assertEqual(stats, {
+            "Outdated": 1,
+            "Multi-Major": 0,
+            "Major": 0,
+            "Minor": 0,
+            "Patch": 1,
+            "Exotic": 0,
+        })

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -74,3 +74,7 @@ class ParseVersionTests(TestCase):
     def test_multi_digit_number_in_name(self):
         version = parse_version("2.10rc1")
         self.assertEqual(version, [2, 10, 0])
+
+    def test_number_after_name_not_used(self):
+        version = parse_version("3.a3.1")
+        self.assertEqual(version, [3, 0, 1])

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from package_metrics.parsing_utils import behind
+from package_metrics.parsing_utils import behind, vsplit
 
 
 class BehindTests(TestCase):
@@ -43,3 +43,22 @@ class BehindTests(TestCase):
     def test_multi_patch_delta(self):
         delta = behind("1.0.5", "1.0.0")
         self.assertEqual(delta, [0, 0, 5])
+
+
+class VsplitTests(TestCase):
+
+    def test_major_minor_patch(self):
+        version = vsplit("3.2.1")
+        self.assertEqual(version, [3, 2, 1])
+
+    def test_major_minor(self):
+        version = vsplit("3.2")
+        self.assertEqual(version, [3, 2, 0])
+
+    def test_major(self):
+        version = vsplit("3")
+        self.assertEqual(version, [3, 0, 0])
+
+    def test_non_semvar(self):
+        version = vsplit("4.3.2.1")
+        self.assertEqual(version, [4, 3, 2])

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from package_metrics.parsing_utils import behind, vsplit
+from package_metrics.parsing_utils import behind, parse_version
 
 
 class BehindTests(TestCase):
@@ -45,20 +45,32 @@ class BehindTests(TestCase):
         self.assertEqual(delta, [0, 0, 5])
 
 
-class VsplitTests(TestCase):
+class ParseVersionTests(TestCase):
 
     def test_major_minor_patch(self):
-        version = vsplit("3.2.1")
+        version = parse_version("3.2.1")
         self.assertEqual(version, [3, 2, 1])
 
     def test_major_minor(self):
-        version = vsplit("3.2")
+        version = parse_version("3.2")
         self.assertEqual(version, [3, 2, 0])
 
     def test_major(self):
-        version = vsplit("3")
+        version = parse_version("3")
         self.assertEqual(version, [3, 0, 0])
 
     def test_non_semvar(self):
-        version = vsplit("4.3.2.1")
+        version = parse_version("4.3.2.1")
         self.assertEqual(version, [4, 3, 2])
+
+    def test_named_version(self):
+        version = parse_version("alpha")
+        self.assertEqual(version, [0, 0, 0])
+
+    def test_combination_of_numbers_and_names(self):
+        version = parse_version("2.1rc1")
+        self.assertEqual(version, [2, 1, 0])
+
+    def test_multi_digit_number_in_name(self):
+        version = parse_version("2.10rc1")
+        self.assertEqual(version, [2, 10, 0])

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from package_metrics.parsing_utils import behind
+
+
+class BehindTests(TestCase):
+    """
+    Tests ``behind(latest, current)``
+    """
+
+    def test_major_delta(self):
+        delta = behind("2.0.0", "1.0.0")
+        self.assertEqual(delta, [1, 0, 0])
+
+    def test_minor_delta(self):
+        delta = behind("1.1.0", "1.0.0")
+        self.assertEqual(delta, [0, 1, 0])
+
+    def test_patch_delta(self):
+        delta = behind("1.0.1", "1.0.0")
+        self.assertEqual(delta, [0, 0, 1])
+
+    def test_major_has_priority_over_minor(self):
+        delta = behind("2.1.0", "1.0.0")
+        self.assertEqual(delta, [1, 0, 0])
+
+    def test_major_has_priority_over_patch(self):
+        delta = behind("2.0.1", "1.0.0")
+        self.assertEqual(delta, [1, 0, 0])
+
+    def test_minor_has_priority_over_patch(self):
+        delta = behind("1.1.1", "1.0.0")
+        self.assertEqual(delta, [0, 1, 0])
+
+    def test_multi_major_delta(self):
+        delta = behind("5.0.0", "1.0.0")
+        self.assertEqual(delta, [4, 0, 0])
+
+    def test_multi_minor_delta(self):
+        delta = behind("1.5.0", "1.0.0")
+        self.assertEqual(delta, [0, 5, 0])
+
+    def test_multi_patch_delta(self):
+        delta = behind("1.0.5", "1.0.0")
+        self.assertEqual(delta, [0, 0, 5])

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -1,0 +1,49 @@
+from unittest import TestCase, mock
+
+from package_metrics.package_managers.pip import parse_pip
+
+
+@mock.patch('package_metrics.package_managers.pip._get_pip_packages')
+class ParsePipTests(TestCase):
+
+    def test_major_version_out_of_date(self, mock_packages):
+        mock_packages.return_value = '[{"name": "test", "version": "1.0", ' \
+                                     '"latest_version": "5.0", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = list(parse_pip())
+        self.assertEqual(result, [([4, 0, 0], 'test', '5.0', '1.0')])
+
+    def test_minor_version_out_of_date(self, mock_packages):
+        mock_packages.return_value = '[{"name": "test", "version": "1.0", ' \
+                                     '"latest_version": "1.7", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = list(parse_pip())
+        self.assertEqual(result, [([0, 7, 0], 'test', '1.7', '1.0')])
+
+    def test_patch_version_out_of_date(self, mock_packages):
+        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
+                                     '"latest_version": "1.0.10", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = list(parse_pip())
+        self.assertEqual(result, [([0, 0, 10], 'test', '1.0.10', '1.0.0')])
+
+    def test_major_has_priority_over_minor(self, mock_packages):
+        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
+                                     '"latest_version": "2.4.0", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = list(parse_pip())
+        self.assertEqual(result, [([1, 0, 0], 'test', '2.4.0', '1.0.0')])
+
+    def test_major_has_priority_over_patch(self, mock_packages):
+        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
+                                     '"latest_version": "2.0.1", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = list(parse_pip())
+        self.assertEqual(result, [([1, 0, 0], 'test', '2.0.1', '1.0.0')])
+
+    def test_minor_has_priority_over_patch(self, mock_packages):
+        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
+                                     '"latest_version": "1.5.1", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = list(parse_pip())
+        self.assertEqual(result, [([0, 5, 0], 'test', '1.5.1', '1.0.0')])

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -26,24 +26,3 @@ class IterPipPackagesTests(TestCase):
                                      '"latest_filetype": "wheel"}]'
         result = list(iter_pip_packages())
         self.assertEqual(result, [([0, 0, 10], 'test', '1.0.10', '1.0.0')])
-
-    def test_major_has_priority_over_minor(self, mock_packages):
-        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
-                                     '"latest_version": "2.4.0", ' \
-                                     '"latest_filetype": "wheel"}]'
-        result = list(iter_pip_packages())
-        self.assertEqual(result, [([1, 0, 0], 'test', '2.4.0', '1.0.0')])
-
-    def test_major_has_priority_over_patch(self, mock_packages):
-        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
-                                     '"latest_version": "2.0.1", ' \
-                                     '"latest_filetype": "wheel"}]'
-        result = list(iter_pip_packages())
-        self.assertEqual(result, [([1, 0, 0], 'test', '2.0.1', '1.0.0')])
-
-    def test_minor_has_priority_over_patch(self, mock_packages):
-        mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
-                                     '"latest_version": "1.5.1", ' \
-                                     '"latest_filetype": "wheel"}]'
-        result = list(iter_pip_packages())
-        self.assertEqual(result, [([0, 5, 0], 'test', '1.5.1', '1.0.0')])

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -1,49 +1,49 @@
 from unittest import TestCase, mock
 
-from package_metrics.package_managers.pip import parse_pip
+from package_metrics.package_managers.pip import iter_pip_packages
 
 
 @mock.patch('package_metrics.package_managers.pip._get_pip_packages')
-class ParsePipTests(TestCase):
+class IterPipPackagesTests(TestCase):
 
     def test_major_version_out_of_date(self, mock_packages):
         mock_packages.return_value = '[{"name": "test", "version": "1.0", ' \
                                      '"latest_version": "5.0", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = list(parse_pip())
+        result = list(iter_pip_packages())
         self.assertEqual(result, [([4, 0, 0], 'test', '5.0', '1.0')])
 
     def test_minor_version_out_of_date(self, mock_packages):
         mock_packages.return_value = '[{"name": "test", "version": "1.0", ' \
                                      '"latest_version": "1.7", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = list(parse_pip())
+        result = list(iter_pip_packages())
         self.assertEqual(result, [([0, 7, 0], 'test', '1.7', '1.0')])
 
     def test_patch_version_out_of_date(self, mock_packages):
         mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
                                      '"latest_version": "1.0.10", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = list(parse_pip())
+        result = list(iter_pip_packages())
         self.assertEqual(result, [([0, 0, 10], 'test', '1.0.10', '1.0.0')])
 
     def test_major_has_priority_over_minor(self, mock_packages):
         mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
                                      '"latest_version": "2.4.0", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = list(parse_pip())
+        result = list(iter_pip_packages())
         self.assertEqual(result, [([1, 0, 0], 'test', '2.4.0', '1.0.0')])
 
     def test_major_has_priority_over_patch(self, mock_packages):
         mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
                                      '"latest_version": "2.0.1", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = list(parse_pip())
+        result = list(iter_pip_packages())
         self.assertEqual(result, [([1, 0, 0], 'test', '2.0.1', '1.0.0')])
 
     def test_minor_has_priority_over_patch(self, mock_packages):
         mock_packages.return_value = '[{"name": "test", "version": "1.0.0", ' \
                                      '"latest_version": "1.5.1", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = list(parse_pip())
+        result = list(iter_pip_packages())
         self.assertEqual(result, [([0, 5, 0], 'test', '1.5.1', '1.0.0')])


### PR DESCRIPTION
This PR adds support for the `pip` workflow. I notably did not port over the following:
- specify file as input stream (I didn't see this used anywhere)
- having to specify `--outdated` (similarly, did not see uses where this was set to false)

These changes result in the following workflows:

Printing the list of packages installed for the current project and how out of date they are.
```
➜  package-metrics git:(gh/implement-pip) package-metrics pip
Behind   Package                      Latest       Version
0.1.0    packaging                    23.1         23.0
0.1.0    pip                          23.1         23.0.1
0.1.0    pip-tools                    6.13.0       6.12.3
0.2.0    wheel                        0.40.0       0.38.4
9.0.0    setuptools                   67.6.1       58.1.0
```

Collecting stats and printing to stdout.
```
➜  package-metrics git:(gh/implement-pip) package-metrics pip --stats
Outdated: 5
Multi-Major: 1
Major: 0
Minor: 4
Patch: 0
Exotic: 0
```

And finally collecting stats and sending to datadog, though I haven't fully tested that with Datadog API credentials.
```
➜  package-metrics git:(gh/implement-pip) package-metrics pip --send
```

**Review by commit** 